### PR TITLE
Bugfix: Compose zero padding missing / Device Error init

### DIFF
--- a/mecom/mecom.py
+++ b/mecom/mecom.py
@@ -135,8 +135,9 @@ class MeFrame(object):
             elif type(p) is int:
                 frame += "{:08X}".format(p)
             elif type(p) is float:
-                frame += hex(unpack('<I', pack('<f', p))[0])[2:].upper()  # please do not ask
-            # frame += p if type(p) is str else "{:08X}".format(p)
+                # frame += hex(unpack('<I', pack('<f', p))[0])[2:].upper()  # please do not ask
+                # if p = 0 CRC fails, e.g. !01000400000000 composes to b'!0100040' / missing zero padding
+                frame += '{:08X}'.format(unpack('<I', pack('<f', p))[0])   #still do not aks
         # if we only want a partial frame, return here
         if part:
             return frame.encode()
@@ -338,8 +339,8 @@ class DeviceError(MeFrame):
         Read error codes from command.py and parse into a list of Error() instances.
         """
         super(DeviceError, self).__init__()
+        self._ERRORS = []
         for error in ERRORS:
-            self._ERRORS = []
             self._ERRORS.append(Error(error))
 
     def _get_by_code(self, code):


### PR DESCRIPTION
Simple bugfix:
- If a returned value is 0 CRC check fails due to missing zero padding when composing the MeFrame. 
- DeviceError._ERRORS currently only contains last error due to empty list init in for loop