### PR TITLE
adding commands GPIO on TEC_PARAMETERS side not only LDD to maintain …

### DIFF
--- a/mecom/commands.py
+++ b/mecom/commands.py
@@ -26,10 +26,18 @@ TEC_PARAMETERS = [
     {"id": 2051, "name": "Device Address", "format": "INT32"},
 
     {"id": 3000, "name": "Target Object Temp (Set)", "format": "FLOAT32"},
+    {"id": 6100, "name": "GPIO Function", "format": "INT32"},
+    {"id": 6101, "name": "GPIO Level Assignment", "format": "INT32"},
+    {"id": 6102, "name": "GPIO Hardware Configuration", "format": "INT32"},
+    {"id": 6103, "name": "GPIO Channel", "format": "INT32"},
 
     {"id": 6300, "name": "Source Selection", "format": "INT32"},
     {"id": 6302, "name": "Observe Mode", "format": "INT32"},
     {"id": 6310, "name": "Delay till Restart", "format": "FLOAT32"},
+    {"id": 52100, "name": "Enable Function", "format": "INT32"},
+    {"id": 52101, "name": "Set Output to Push-Pull", "format": "INT32"},
+    {"id": 52102, "name": "Set Output States", "format": "INT32"},
+    {"id": 52103, "name": "Read Input States", "format": "INT32"},
 
     {"id": 50000, "name": "Live Enable", "format": "INT32"},
 


### PR DESCRIPTION
just additional definitions to allow further use (gpio control)

Realized that I added the commands on LDD_PARAMETERS side only but my legacy sw does not have this split LDD/TEC and default gets TEC (changing this to LDD creates issues on other needed TEC parameters then heavy code refactoring is needed).

Saw that other parameters are already declared/dupplicated on both sides

Declaring the commands in TEC_PARAMETERS make compatibility with legacy sw smooth.

Not sure in the end if it should be kept in both places of only on TEC side...