### PR TITLE
Installation of dependencies (fix typo in setup.py)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='mecom',
     version='0.1',
     packages=['mecom'],
-    install_requirements = ['pySerial>=3.4',
+    install_requires = ['pySerial>=3.4',
                             'PyCRC'],
     url='https://github.com/spomjaksilp/pyMeCom',
     license='',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1',
     packages=['mecom'],
     install_requires = ['pySerial>=3.4',
-                            'PyCRC'],
+                        'pythoncrc'],
     url='https://github.com/spomjaksilp/pyMeCom',
     license='',
     author='Suthep Pomjaksilp',


### PR DESCRIPTION
Fixes #15 

Currently, the setup.py file contains the field `install_requirements`. This does not any effect upon installation of the mecom package, such that its dependencies are not installed. Changing it to `install_requires` fixes this problem. 

Additionally, the correct package name of pyCRC (pythoncrc) is inserted in the setup.py.
