### PR TITLE
Add a `get_parameter_raw()` and a `set_parameter_raw()` method to specify parameters not in commands.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ This package was developed to control several TEC devices on a raspberry pi by c
 For a basic example look at `mecom/mecom.py`, the `__main__` part contains an example communication.
 
 ## Additional parameters to get/set
-Only parameters present in `mecom/commands.py` can be used, this is a security feature in case someone uses a parameter like "flash firmware" by accident.
-Feel free to add more parameters to `mecom/commands.py`.
+Only parameters present in `mecom/commands.py` can be used with the regular functions, this is a security feature in case someone uses a parameter like "flash firmware" by accident.
+Use the *_raw functions if you need access to parameters not in `mecom/commands.py`.
+Furthermore, feel free to add more parameters to `mecom/commands.py`.
 
 ## Contribution
 This is by no means a polished software, contribution by submitting to this repository is appreciated.


### PR DESCRIPTION
The `*_raw` versions of the parameter functions allow using parameters by specifying id and format parameters, independent of the list in the commands.py file.
Being able to specify the parameter freely is useful during development when testing out a variety of parameters and when working with less common parameters, as there are numerous parameters, many of which can be device or firmware specific.
This is a feature that is often requested by some of our customers who are using the pyMeCom interface.

This pull request represents a suggestion of how this functionality can be implemented. We also thought about implementing it directly into the existing `get_parameter` and `set_parameter` functions, but ultimately decided against it to not work against the security principle stated in the README. However, any improvement suggestions are very welcome.